### PR TITLE
Minor depth calculation fixes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,9 +6,10 @@
 A php-package for parsing and evaluating the [yarn.lock](https://yarnpkg.com/lang/en/docs/yarn-lock/) format.
 
 ## Basic Usage
+
 ```php
 <?php
-use Mindscreen\YarnLock;
+use Mindscreen\YarnLock\YarnLock;
 
 $yarnLock = YarnLock::fromString(file_get_contents('yarn.lock'));
 
@@ -19,10 +20,13 @@ $babelCoreDependencies = $babelCorePackages[0]->getDependencies();
 ```
 
 ## Package Depth
+
 If you maybe don't just want all packages but only the direct dependencies plus one level of indirection, you have to go a little extra mile:
+
 ```php
 <?php
-use Mindscreen\YarnLock;
+use Mindscreen\YarnLock\YarnLock;
+
 // read the dependencies from the package.json file
 $packageDependencies = (json_decode(file_get_contents('package.json')))->dependencies;
 // get these packages from the yarn lock-file

--- a/readme.md
+++ b/readme.md
@@ -21,22 +21,11 @@ $babelCoreDependencies = $babelCorePackages[0]->getDependencies();
 
 ## Package Depth
 
-If you maybe don't just want all packages but only the direct dependencies plus one level of indirection, you have to go a little extra mile:
+You can also query packages by depth:
 
 ```php
-<?php
-use Mindscreen\YarnLock\YarnLock;
-
-// read the dependencies from the package.json file
-$packageDependencies = (json_decode(file_get_contents('package.json')))->dependencies;
-// get these packages from the yarn lock-file
-$rootDependencies = array_map(function($packageName, $packageVersion) use ($yarnLock) {
-    return $yarnLock->getPackage($packageName, $packageVersion);
-}, array_keys($packageDependencies), array_values($packageDependencies));
-// some of our dependencies might be used by other dependencies deeper down the tree so
-// they wouldn't appear in the top levels, if we wouldn't explicitly set them there.
-$yarnLock->calculateDepth($rootDependencies);
-
-// get the first two levels; the second argument is the exclusive upper limit
-$yarnLock->getPackagesByDepth(0, 2);
+// Get just the direct dependencies.
+$directDependencies = $yarnLock->getPackagesByDepth(0);
+// Get the first two levels of dependencies.
+$firstTwoLevels = $yarnLock->getPackagesByDepth(0, 2);
 ```

--- a/src/Package.php
+++ b/src/Package.php
@@ -59,7 +59,7 @@ class Package
      *
      * @var Package[]
      */
-    protected $resolves;
+    protected $resolves = [];
 
     /**
      * Depth in the dependency tree. Only initialized once the YarnLock computes
@@ -208,9 +208,6 @@ class Package
      */
     public function addResolves(Package $package)
     {
-        if ($this->resolves === null) {
-            $this->resolves = [];
-        }
         if (in_array($package, $this->resolves)) {
             return;
         }

--- a/src/YarnLock.php
+++ b/src/YarnLock.php
@@ -133,6 +133,7 @@ class YarnLock
      */
     public function getPackagesByDepth($start, $end = 0)
     {
+        $this->calculateDepth();
         if ($end === 0 || ($end !== null && $end < $start)) {
             $end = $start + 1;
         }


### PR DESCRIPTION
Hi! Thanks for creating this package, it's really useful!

bbe2e0e fixes an issue where `calculateDepth()` (with no roots) fails because `resolves = null`. The check for `count($p->getResolves())` always fails, because `resolves` couldn't ever be an empty array.

aa463f0 just ensures `calculateDepth()` has run when you use `getPackagesByDepth()`. Otherwise, the latter always returns an empty array. (`getDepth()` already does the same.)

5558b05 and 3c77397 are readme fixes. It seems like the readme was outdated, maybe? There's no need to parse `package.json`, and just doing `getPackagesByDepth(0)` works fine for me.